### PR TITLE
Add metadata API Net Route for Win container

### DIFF
--- a/doc_source/windows_task_IAM_roles.md
+++ b/doc_source/windows_task_IAM_roles.md
@@ -35,5 +35,6 @@ Before containers can access the credential proxy on the container instance to g
 
 $gateway = (Get-NetRoute | Where { $_.DestinationPrefix -eq '0.0.0.0/0' } | Sort-Object RouteMetric | Select NextHop).NextHop
 $ifIndex = (Get-NetAdapter -InterfaceDescription "Hyper-V Virtual Ethernet*" | Sort-Object | Select ifIndex).ifIndex
-New-NetRoute -DestinationPrefix 169.254.170.2/32 -InterfaceIndex $ifIndex -NextHop $gateway
+New-NetRoute -DestinationPrefix 169.254.170.2/32 -InterfaceIndex $ifIndex -NextHop $gateway # credentials API
+New-NetRoute -DestinationPrefix 169.254.169.254/32 -InterfaceIndex $ifIndex -NextHop $gateway # metadata API
 ```


### PR DESCRIPTION
Adds a route to the metadata api (169.254.169.254) this permits a docker container to perform the following to fetch the instance ID of the container host it is running on. 

```powershell
Invoke-WebRequest http://169.254.169.254/latest/meta-data/instance-id -UseBasicParsing
```

Prior to this we also encountered the following error when using the AWS .NET SDK 

```csharp
Error: Error Code: AWSSDK.Core  Type: Amazon.Runtime.AmazonServiceException  HttpStatusCode:
    at Amazon.Runtime.DefaultInstanceProfileAWSCredentials.FetchCredentials() 
    at Amazon.Runtime.DefaultInstanceProfileAWSCredentials.GetCredentials() 
    at Amazon.Runtime.Internal.CredentialsRetriever.PreInvoke(IExecutionContext executionContext) 
    at Amazon.Runtime.Internal.CredentialsRetriever.InvokeSync(IExecutionContext executionContext) 
    at Amazon.Runtime.Internal.RetryHandler.InvokeSync(IExecutionContext executionContext) 
    at Amazon.Runtime.Internal.CallbackHandler.InvokeSync(IExecutionContext executionContext) 
    at Amazon.Runtime.Internal.CallbackHandler.InvokeSync(IExecutionContext executionContext) 
    at Amazon.S3.Internal.AmazonS3ExceptionHandler.InvokeSync(IExecutionContext executionContext) 
    at Amazon.Runtime.Internal.ErrorCallbackHandler.InvokeSync(IExecutionContext executionContext) 
    at Amazon.Runtime.Internal.MetricsHandler.InvokeSync(IExecutionContext executionContext) 
    at Amazon.Runtime.Internal.RuntimePipeline.InvokeSync(IExecutionContext executionContext) 
    at Amazon.Runtime.AmazonServiceClient.Invoke[TResponse](AmazonWebServiceRequest request, InvokeOptionsBase options) 
    at Amazon.S3.Util.AmazonS3Util.DoesS3BucketExistV2(IAmazonS3 s3Client, String bucketName) 
```

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
